### PR TITLE
Adapted for RISCV

### DIFF
--- a/md.h
+++ b/md.h
@@ -191,8 +191,17 @@
             /* https://github.com/ossrs/state-threads/issues/24 */
             #define MD_USE_BUILTIN_SETJMP
             #define MD_GET_SP(_t) *((long *)&((_t)->context[0].__jmpbuf[0]))
-
-        #else
+		
+		#elif defined(__riscv)
+			#if defined(__GLIBC__)   && __GLIBC__ >= 2
+				#undef MD_USE_BUILTIN_SETJMP
+			#else
+				#define MD_USE_BUILTIN_SETJMP
+				#error "RISCV/Linux pre-glibc2 not supported yet"
+			#endif
+			#define MD_GET_SP(_t) *((long *)&((_t)->context[0].__jmpbuf[0].__sp))
+			
+		#else
             #error "Unknown CPU architecture"
         #endif /* Cases with common MD_INIT_CONTEXT and different SP locations */
 

--- a/md_linux.S
+++ b/md_linux.S
@@ -510,6 +510,129 @@
 
     /****************************************************************/
 
+
+
+
+
+
+
+
+#elif defined(__riscv)
+
+     /****************************************************************/
+	#if __riscv_xlen == 64
+	# define PTRLOG 3
+	# define SZREG  8
+	# define REG_S sd
+	# define REG_L ld
+	#elif __riscv_xlen == 32
+	# define PTRLOG 2
+	# define SZREG  4
+	# define REG_S sw
+	# define REG_L lw
+	#else
+	# error __riscv_xlen must equal 32 or 64
+	#endif
+	
+	
+	#if !defined __riscv_float_abi_soft
+	/* For ABI uniformity, reserve 8 bytes for floats, even if double-precision
+	   floating-point is not supported in hardware.  */
+	# if defined __riscv_float_abi_double
+	#  define FREG_L fld
+	#  define FREG_S fsd
+	#  define SZFREG 8
+	# else
+	#  error unsupported FLEN
+	# endif
+	#endif
+
+    .file "md.S"
+    .text
+
+    /* _st_md_cxt_save(__jmp_buf env) */
+    .globl _st_md_cxt_save
+        .type _st_md_cxt_save, @function
+        .align 16
+    _st_md_cxt_save:
+        /*
+         * Save registers.
+         */
+		REG_S ra,  0*SZREG(a0)
+		REG_S s0,  1*SZREG(a0)
+		REG_S s1,  2*SZREG(a0)
+		REG_S s2,  3*SZREG(a0)
+		REG_S s3,  4*SZREG(a0)
+		REG_S s4,  5*SZREG(a0)
+		REG_S s5,  6*SZREG(a0)
+		REG_S s6,  7*SZREG(a0)
+		REG_S s7,  8*SZREG(a0)
+		REG_S s8,  9*SZREG(a0)
+		REG_S s9, 10*SZREG(a0)
+		REG_S s10,11*SZREG(a0)
+		REG_S s11,12*SZREG(a0)
+		REG_S sp, 13*SZREG(a0)
+	#ifndef __riscv_float_abi_soft
+		FREG_S fs0, 14*SZREG+ 0*SZFREG(a0)
+		FREG_S fs1, 14*SZREG+ 1*SZFREG(a0)
+		FREG_S fs2, 14*SZREG+ 2*SZFREG(a0)
+		FREG_S fs3, 14*SZREG+ 3*SZFREG(a0)
+		FREG_S fs4, 14*SZREG+ 4*SZFREG(a0)
+		FREG_S fs5, 14*SZREG+ 5*SZFREG(a0)
+		FREG_S fs6, 14*SZREG+ 6*SZFREG(a0)
+		FREG_S fs7, 14*SZREG+ 7*SZFREG(a0)
+		FREG_S fs8, 14*SZREG+ 8*SZFREG(a0)
+		FREG_S fs9, 14*SZREG+ 9*SZFREG(a0)
+		FREG_S fs10,14*SZREG+10*SZFREG(a0)
+		FREG_S fs11,14*SZREG+11*SZFREG(a0)
+	#endif
+		li a0, 0
+		ret
+    .size _st_md_cxt_save, .-_st_md_cxt_save
+
+
+    /****************************************************************/
+
+    /* _st_md_cxt_restore(__jmp_buf env, int val) */
+    .globl _st_md_cxt_restore
+        .type _st_md_cxt_restore, @function
+        .align 16
+    _st_md_cxt_restore:
+        REG_L ra,  0*SZREG(a0)
+		REG_L s0,  1*SZREG(a0)
+		REG_L s1,  2*SZREG(a0)
+		REG_L s2,  3*SZREG(a0)
+		REG_L s3,  4*SZREG(a0)
+		REG_L s4,  5*SZREG(a0)
+		REG_L s5,  6*SZREG(a0)
+		REG_L s6,  7*SZREG(a0)
+		REG_L s7,  8*SZREG(a0)
+		REG_L s8,  9*SZREG(a0)
+		REG_L s9, 10*SZREG(a0)
+		REG_L s10,11*SZREG(a0)
+		REG_L s11,12*SZREG(a0)
+		REG_L sp, 13*SZREG(a0)
+
+	#ifndef __riscv_float_abi_soft
+		FREG_L fs0, 14*SZREG+ 0*SZFREG(a0)
+		FREG_L fs1, 14*SZREG+ 1*SZFREG(a0)
+		FREG_L fs2, 14*SZREG+ 2*SZFREG(a0)
+		FREG_L fs3, 14*SZREG+ 3*SZFREG(a0)
+		FREG_L fs4, 14*SZREG+ 4*SZFREG(a0)
+		FREG_L fs5, 14*SZREG+ 5*SZFREG(a0)
+		FREG_L fs6, 14*SZREG+ 6*SZFREG(a0)
+		FREG_L fs7, 14*SZREG+ 7*SZFREG(a0)
+		FREG_L fs8, 14*SZREG+ 8*SZFREG(a0)
+		FREG_L fs9, 14*SZREG+ 9*SZFREG(a0)
+		FREG_L fs10,14*SZREG+10*SZFREG(a0)
+		FREG_L fs11,14*SZREG+11*SZFREG(a0)
+	#endif
+		seqz a0, a1
+		add  a0, a0, a1   # a0 = (a1 == 0) ? 1 : a1
+		ret
+    .size _st_md_cxt_restore, .-_st_md_cxt_restore
+
+    /****************************************************************/
 #endif
 
 #endif

--- a/tools/porting/porting.c
+++ b/tools/porting/porting.c
@@ -153,6 +153,46 @@ void print_jmpbuf()
     unsigned char* p = (unsigned char*)ctx[0].__jmpbuf;
     print_buf(p, nn_jb);
 }
+#elif defined( __riscv )
+void print_jmpbuf()
+{
+	void  *ra, *s0, *s1, *s2, *s3, *s4, *s5;
+	void  *s6, *s7, *s8, *s9, *s10, *s11, *sp;
+	
+    __asm__ __volatile__ ("mv %0,ra": "=r"(ra): /* No input */);
+	__asm__ __volatile__ ("mv %0,s0": "=r"(s0): /* No input */);
+	__asm__ __volatile__ ("mv %0,s1": "=r"(s1): /* No input */);
+	__asm__ __volatile__ ("mv %0,s2": "=r"(s2): /* No input */);
+	__asm__ __volatile__ ("mv %0,s3": "=r"(s3): /* No input */);
+	__asm__ __volatile__ ("mv %0,s4": "=r"(s4): /* No input */);
+	__asm__ __volatile__ ("mv %0,s5": "=r"(s5): /* No input */);
+	__asm__ __volatile__ ("mv %0,s6": "=r"(s6): /* No input */);
+	__asm__ __volatile__ ("mv %0,s7": "=r"(s7): /* No input */);
+	__asm__ __volatile__ ("mv %0,s8": "=r"(s8): /* No input */);
+	__asm__ __volatile__ ("mv %0,s9": "=r"(s9): /* No input */);
+	__asm__ __volatile__ ("mv %0,s10": "=r"(s10): /* No input */);
+	__asm__ __volatile__ ("mv %0,s11": "=r"(s11): /* No input */);
+	__asm__ __volatile__ ("mv %0,sp": "=r"(sp): /* No input */);                                       
+	printf("ra=%p, s0=%p\n", ra, s0);
+	printf("s1=%p, s2=%p\n", s1, s2);
+	printf("s3=%p, s4=%p\n", s3, s4);
+	printf("s5=%p, s6=%p\n", s5, s6);
+	printf("s7=%p, s8=%p\n", s7, s8);
+	printf("s9=%p, s10=%p\n", s9, s10);
+	printf("s11=%p, sp=%p\n", s11, sp);
+
+    jmp_buf ctx = {0};
+    int r0 = setjmp(ctx);
+    if (!r0) {
+        longjmp(ctx, 1);
+    }
+
+    int nn_jb = sizeof(ctx);
+    printf("sizeof(jmp_buf)=%d (unsigned long long [%d])\n", nn_jb, nn_jb/8);
+
+    unsigned char* p = (unsigned char*)ctx;
+    print_buf(p, nn_jb); 
+}
 #endif
 #endif
 


### PR DESCRIPTION
Now risc-v is more and more popular. 
Support risc-v is very easy.

my code take some example from libc
https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/riscv/swapcontext.S;h=53480a085c3418b5ba84ba115785f40f3c19ad89;hb=HEAD

If have glic  and glibc version is bigger than 2.0, use glibc's  setjmp and longjmp .
If no glibc , use that in md_linux.S

